### PR TITLE
Fix link to RFC (parameter choice)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The hash function takes in the following parameters:
 - **version** : Argon2 algorithm version number.
 - **encoding** : Encoding for the returned hash type ('raw', 'hex' or 'b64').
 
-For assistance with parameter selection refer to the [draft RFC](https://www.ietf.org/id/draft-irtf-cfrg-argon2-10.txt), in particular "Chapter 4: Parameter Choice".
+For assistance with parameter selection refer to the [draft RFC](https://www.rfc-editor.org/rfc/rfc9106.html#section-4), in particular "Chapter 4: Parameter Choice".
 
 ### Function Exceptions
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The hash function takes in the following parameters:
 - **version** : Argon2 algorithm version number.
 - **encoding** : Encoding for the returned hash type ('raw', 'hex' or 'b64').
 
-For assistance with parameter selection refer to the [draft RFC](https://www.rfc-editor.org/rfc/rfc9106.html#section-4), in particular "Chapter 4: Parameter Choice".
+For assistance with parameter selection refer to [RFC 9106](https://www.rfc-editor.org/rfc/rfc9106.html#section-4), in particular "Chapter 4: Parameter Choice".
 
 ### Function Exceptions
 


### PR DESCRIPTION
Hey! I am making a hobby project and storing some passwords using argon. Thanks for making this implementation, it will be nice to use.

I noticed that your link to the argon2 RFC is broken for me (maybe because it's out of draft now?) and found a link that works (for me at least): https://www.rfc-editor.org/rfc/rfc9106.html

This IETF bloggish post [How to read RFCs](https://www.ietf.org/blog/how-read-rfc) recommends using [https://www.rfc-editor.org](https://www.rfc-editor.org) to read RFCs, that's why I chose this host to link to.