### PR TITLE
Introduce function accepting byte array inputs for hashing

### DIFF
--- a/pyargon2/argon2.py
+++ b/pyargon2/argon2.py
@@ -22,7 +22,8 @@ def hash(password: str, salt: str, pepper: str = "",
          version: int = lib.ARGON2_VERSION_NUMBER,
          encoding: str = 'hex'):
     """
-    The Argon2 hashing function defined in draft RFC (https://www.ietf.org/id/draft-irtf-cfrg-argon2-10.txt).
+    The string input version of the Argon2 hashing function.
+    Implemented based on the definitions in RFC (https://www.ietf.org/id/draft-irtf-cfrg-argon2-10.txt).
     :param password: Password string.
     :param salt: Salt string to use for the password hash (must be unique for each hash).
     :param pepper: Optional pepper string to fold into the hash (keyed hashing).
@@ -37,19 +38,92 @@ def hash(password: str, salt: str, pepper: str = "",
     :return: Hash of password in format specified by the 'encoding' parameter.
     """
     # Check types of all parameters before proceeding
-    _check_params(password, salt, pepper, hash_len, time_cost, memory_cost,
-                  parallelism, flags, variant, version, encoding)
+    __check_params(str, password, salt, pepper, hash_len, time_cost, memory_cost,
+                   parallelism, flags, variant, version, encoding)
 
     # Convert to Unicode
     password = password.encode('utf-8')
     salt = salt.encode('utf-8')
+    pepper = pepper.encode('utf-8')
 
+    raw_hash = __raw_hash(password, salt, pepper, hash_len, time_cost, memory_cost,
+                          parallelism, flags, variant, version)
+
+    if encoding == 'hex':
+        return raw_hash.hex()
+    elif encoding == 'b64':
+        return base64.b64encode(raw_hash).decode('ascii')
+    elif encoding == 'raw':
+        return raw_hash
+
+
+def hash_bytes(password: bytes, salt: bytes, pepper: bytes = b'',
+               hash_len: int = DEFAULT_HASH_LENGTH,
+               time_cost: int = DEFAULT_TIME_COST,
+               memory_cost: int = DEFAULT_MEMORY_COST,
+               parallelism: int = DEFAULT_PARALLELISM,
+               flags: int = DEFAULT_FLAGS,
+               variant: str = "id",
+               version: int = lib.ARGON2_VERSION_NUMBER,
+               encoding: str = 'hex'):
+    """
+    The byte array input version of the Argon2 hashing function.
+    Implemented based on the definitions in RFC (https://www.ietf.org/id/draft-irtf-cfrg-argon2-10.txt).
+    :param password: Password byte array.
+    :param salt: Salt byte array to use for the password hash (must be unique for each hash).
+    :param pepper: Optional pepper byte array to fold into the hash (keyed hashing).
+    :param hash_len: Output length of hash in bytes.
+    :param time_cost: Number of iterations to perform.
+    :param memory_cost: Memory size in Kibibytes (1024 bytes).
+    :param parallelism: How many independent computations chains (lanes) to run.
+    :param flags: Flags to determine which fields are securely wiped.
+    :param variant: Argon2 algorithm variant ('i', 'd', or 'id').
+    :param version: Argon2 algorithm version number.
+    :param encoding: Encoding for the returned hash type ('raw', 'hex' or 'b64').
+    :return: Hash of password in format specified by the 'encoding' parameter.
+    """
+    # Check types of all parameters before proceeding
+    __check_params(bytes, password, salt, pepper, hash_len, time_cost, memory_cost,
+                   parallelism, flags, variant, version, encoding)
+
+    raw_hash = __raw_hash(password, salt, pepper, hash_len, time_cost, memory_cost,
+                          parallelism, flags, variant, version)
+
+    if encoding == 'hex':
+        return raw_hash.hex()
+    elif encoding == 'b64':
+        return base64.b64encode(raw_hash).decode('ascii')
+    elif encoding == 'raw':
+        return raw_hash
+
+
+def __raw_hash(password: bytes, salt: bytes, pepper: bytes = b'',
+               hash_len: int = DEFAULT_HASH_LENGTH,
+               time_cost: int = DEFAULT_TIME_COST,
+               memory_cost: int = DEFAULT_MEMORY_COST,
+               parallelism: int = DEFAULT_PARALLELISM,
+               flags: int = DEFAULT_FLAGS,
+               variant: str = "id",
+               version: int = lib.ARGON2_VERSION_NUMBER):
+    """
+    The underlying raw Argon2 hashing function defined in RFC (https://www.ietf.org/id/draft-irtf-cfrg-argon2-10.txt).
+    :param password: Password byte array.
+    :param salt: Salt byte array to use for the password hash (must be unique for each hash).
+    :param pepper: Optional pepper byte array to fold into the hash (keyed hashing).
+    :param hash_len: Output length of hash in bytes.
+    :param time_cost: Number of iterations to perform.
+    :param memory_cost: Memory size in Kibibytes (1024 bytes).
+    :param parallelism: How many independent computations chains (lanes) to run.
+    :param flags: Flags to determine which fields are securely wiped.
+    :param variant: Argon2 algorithm variant ('i', 'd', or 'id').
+    :param version: Argon2 algorithm version number.
+    :return: Hash of password in raw format.
+    """
     # Create C variables
     csalt = ffi.new("uint8_t[]", salt)
     chash = ffi.new("uint8_t[]", hash_len)
     cpwd = ffi.new("uint8_t[]", password)
     if pepper:
-        pepper = pepper.encode('utf-8')
         csecret = ffi.new("uint8_t[]", pepper)
         secret_len = len(pepper)
     else:
@@ -81,31 +155,25 @@ def hash(password: str, salt: str, pepper: str = "",
     if rc != 0:
         raise errors.Argon2Error(errors.Argon2ErrorCode(rc).name)
 
-    # Extract result and return in appropriate format
-    raw_hash = bytes(ffi.buffer(chash, hash_len))
-    if encoding == 'hex':
-        return raw_hash.hex()
-    elif encoding == 'b64':
-        return base64.b64encode(raw_hash).decode('ascii')
-    elif encoding == 'raw':
-        return raw_hash
+    # Extract result and return raw hash
+    return bytes(ffi.buffer(chash, hash_len))
 
 
-def _check_params(password, salt, pepper, hash_len, time_cost, memory_cost,
-                  parallelism, flags, variant, version, encoding):
+def __check_params(input_type, password, salt, pepper, hash_len, time_cost, memory_cost,
+                   parallelism, flags, variant, version, encoding):
     """
     Type check all input parameters before dispatching to low-level C.
     """
-    if type(password) != str: raise ValueError('password must be of string type')
-    if type(salt) != str: raise ValueError('salt must be of string type')
-    if type(pepper) != str: raise ValueError('pepper must be of string type')
-    if type(hash_len) != int: raise ValueError('pepper must be of integer type')
-    if type(time_cost) != int: raise ValueError('time_cost must be of integer type')
-    if type(memory_cost) != int: raise ValueError('memory_cost must be of integer type')
-    if type(parallelism) != int: raise ValueError('parallelism must be of integer type')
-    if type(flags) != int: raise ValueError('flags must be of integer type')
-    if type(variant) != str: raise ValueError('variant must be of string type')
+    if type(password) != input_type: raise ValueError('password must be of type ' + input_type.__name__)
+    if type(salt) != input_type: raise ValueError('salt must be of type ' + input_type.__name__)
+    if type(pepper) != input_type: raise ValueError('pepper must be of type ' + input_type.__name__)
+    if type(hash_len) != int: raise ValueError('pepper must be of type int')
+    if type(time_cost) != int: raise ValueError('time_cost must be of type int')
+    if type(memory_cost) != int: raise ValueError('memory_cost must be of type int')
+    if type(parallelism) != int: raise ValueError('parallelism must be of type int')
+    if type(flags) != int: raise ValueError('flags must be of type int')
+    if type(variant) != str: raise ValueError('variant must be of type str')
     if variant not in ['d', 'i', 'id']: raise ValueError(variant + ' is not a valid Argon2 variant.')
-    if type(version) != int: raise ValueError('version must be of integer type')
-    if type(encoding) != str: raise ValueError('encoding must be of string type')
+    if type(version) != int: raise ValueError('version must be of type int')
+    if type(encoding) != str: raise ValueError('encoding must be of type str')
     if encoding not in ['hex', 'b64', 'raw']: raise ValueError(encoding + ' is not a valid Argon2 encoding.')


### PR DESCRIPTION
This builds upon the ideas in PR #6 by @kirill406. However, it goes further in terms of input type checks and splits out the respective `str` and `bytes` hashing functions to both rely on a more low-level CFFI interop function.

Fixes #4